### PR TITLE
Windows fix?

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -216,7 +216,8 @@ return {
 	{
 		'mfussenegger/nvim-dap',        -- debugger adapter protocol
 		dependencies = {
-			'rcarriga/nvim-dap-ui',     --batteries-included debugger ui
+			'rcarriga/nvim-dap-ui',     -- batteries-included debugger ui
+			'nvim-neotest/nvim-nio',    -- explicit dependency
 		},
 		config = function()
 			local dap = require('dap')


### PR DESCRIPTION
Actually tried this on Windows for the first time, and it turns out, it will fail to set up if you don't explicitly reference this dependency.